### PR TITLE
fast pretty indent regression fixes

### DIFF
--- a/SimpleXmlLexer.cpp
+++ b/SimpleXmlLexer.cpp
@@ -153,6 +153,12 @@ Token SimpleXmlLexer::TryGetAttribute() {
         return Token::Whitespace;
     }
 
+    if (IsLinebreak(*pos)) {
+        for (pos++; pos < endpos && IsLinebreak(*pos); pos++);
+        tokenEnd = pos;
+        return Token::Linebreak;
+    }
+
     for (; pos < endpos; pos++) {
         if (inAttrVal) {
             if (*pos == attrBoundary) {
@@ -163,7 +169,7 @@ Token SimpleXmlLexer::TryGetAttribute() {
             inAttrVal = true;
             attrBoundary = *pos;
         }
-        else if (IsWhitespace(*pos))
+        else if (IsWhitespace(*pos) || IsLinebreak(*pos))
             break;
         else if (*pos == '/' || *pos == '>')
             break;

--- a/XmlPrettyPrinter.h
+++ b/XmlPrettyPrinter.h
@@ -29,12 +29,14 @@ class XmlPrettyPrinter {
     size_t prevTagLen = 0;
 
     inline void TryCloseTag();
+    inline void Indent();
     inline void TryIndent();
     inline void AddNewline();
     inline void StartNewElement();
     inline void WriteToken();
     inline void WriteEatToken();
     void Parse();
+    void ParseAttributes();
 
 public:
     XmlPrettyPrinter(const char* txt, size_t textlen, PrettyPrintParms parms) :lexer(txt, textlen), parms(parms) {


### PR DESCRIPTION
Noticed the split in whitespace to spaces and linebreaks
There were regression errors in a few places that I fixed.

Both regular and indent version should work ok now
Moved duplicate attribute parsing to separate function.