### PR TITLE
Unit tests based on in/out files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 /Win32/Release
 /x64/Debug
 /x64/Release
+/packages/Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3
+/UnitTests/x64/Debug
+/UnitTests/x64/Release
+/UnitTests//Win32/Debug
+/UnitTests/Win32/Release
+/UnitTests/Debug
+/UnitTests/Release

--- a/UnitTests/StdAfx.cpp
+++ b/UnitTests/StdAfx.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to the pre-compiled header
+
+#include "StdAfx.h"
+
+// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/UnitTests/StdAfx.h
+++ b/UnitTests/StdAfx.h
@@ -1,0 +1,14 @@
+// pch.h: This is a precompiled header file.
+// Files listed below are compiled only once, improving build performance for future builds.
+// This also affects IntelliSense performance, including code completion and many code browsing features.
+// However, files listed here are ALL re-compiled if any one of them is updated between builds.
+// Do not add files here that you will be updating frequently as this negates the performance advantage.
+
+#ifndef PCH_H
+#define PCH_H
+
+// add headers that you want to pre-compile here
+
+#include "gtest/gtest.h"
+
+#endif //PCH_H

--- a/UnitTests/TestFiles/PrettyPrintFiles/Comment_After_PI.in.xml
+++ b/UnitTests/TestFiles/PrettyPrintFiles/Comment_After_PI.in.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" ?><!--  A SAMPLE set of slides  -->

--- a/UnitTests/TestFiles/PrettyPrintFiles/Comment_After_PI.out.xml
+++ b/UnitTests/TestFiles/PrettyPrintFiles/Comment_After_PI.out.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" ?>
+<!--  A SAMPLE set of slides  -->

--- a/UnitTests/TestFiles/PrettyPrintFiles/Test1.in.xml
+++ b/UnitTests/TestFiles/PrettyPrintFiles/Test1.in.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><hello some='att' and='more'><This attr1="fo>o " attr2="sad<fa>/fa>sdf " isattributenovalue/>Greatballsoffire<foo/>whoooaaaaayeahsomeentertabtabtab</hello>fdgdgf

--- a/UnitTests/TestFiles/PrettyPrintFiles/Test1.out.xml
+++ b/UnitTests/TestFiles/PrettyPrintFiles/Test1.out.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<hello some='att' and='more'>
+	<This attr1="fo>o " attr2="sad<fa>/fa>sdf " isattributenovalue/>
+	Greatballsoffire
+	<foo/>
+	whoooaaaaayeahsomeentertabtabtab
+</hello>
+fdgdgf

--- a/UnitTests/UnitTests.vcxproj
+++ b/UnitTests/UnitTests.vcxproj
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8b318363-5296-424f-956f-3dc409cf020e}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClInclude Include="..\SimpleXmlLexer.h" />
+    <ClInclude Include="..\XmlPrettyPrinter.h" />
+    <ClInclude Include="StdAfx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\SimpleXmlLexer.cpp" />
+    <ClCompile Include="..\XmlPrettyPrinter.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="XmlPrettyPrinterTests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemDefinitionGroup />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+    <PostBuildEvent>
+      <Command>ROBOCOPY  /E "$(ProjectDir)TestFiles" "$(TargetDir)TestFiles"
+if %errorlevel% leq 1 exit 0 else exit %errorlevel%</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+    <PostBuildEvent>
+      <Command>ROBOCOPY  /E "$(ProjectDir)TestFiles" "$(TargetDir)TestFiles"
+if %errorlevel% leq 1 exit 0 else exit %errorlevel%</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <PostBuildEvent>
+      <Command>ROBOCOPY  /E "$(ProjectDir)TestFiles" "$(TargetDir)TestFiles"
+if %errorlevel% leq 1 exit 0 else exit %errorlevel%</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+    <PostBuildEvent>
+      <Command>ROBOCOPY  /E "$(ProjectDir)TestFiles" "$(TargetDir)TestFiles"
+if %errorlevel% leq 1 exit 0 else exit %errorlevel%</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/UnitTests/UnitTests.vcxproj.filters
+++ b/UnitTests/UnitTests.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="XmlTools">
+      <UniqueIdentifier>{95d80086-47f5-432e-a9fa-bdd1ae1f5bf5}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\SimpleXmlLexer.cpp">
+      <Filter>XmlTools</Filter>
+    </ClCompile>
+    <ClCompile Include="..\XmlPrettyPrinter.cpp">
+      <Filter>XmlTools</Filter>
+    </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
+    <ClCompile Include="XmlPrettyPrinterTests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\SimpleXmlLexer.h">
+      <Filter>XmlTools</Filter>
+    </ClInclude>
+    <ClInclude Include="..\XmlPrettyPrinter.h">
+      <Filter>XmlTools</Filter>
+    </ClInclude>
+    <ClInclude Include="StdAfx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/UnitTests/UnitTests.vcxproj.user
+++ b/UnitTests/UnitTests.vcxproj.user
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerEnvironment>$(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/UnitTests/XmlPrettyPrinterTests.cpp
+++ b/UnitTests/XmlPrettyPrinterTests.cpp
@@ -1,0 +1,93 @@
+#include "StdAfx.h"
+
+#include <fstream>
+#include <filesystem>
+namespace fs = std::filesystem;
+
+#include "../XmlPrettyPrinter.h"
+
+static bool endsWith(const std::string& str, const std::string& suffix) // waiting for C++20....
+{
+    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+static std::string replace(std::string& s, const std::string& find, const char *replace) {
+    auto pos = s.find(find, find.size());
+    if (pos != std::string::npos) {
+        s.replace(pos, find.size(), replace);
+    }
+    return s;
+}
+
+char* readFile(const fs::directory_entry& entry) {
+    auto size = entry.file_size();
+    std::ifstream inputStream(entry.path().string(), std::ios_base::binary | std::ios_base::in);
+    if (!inputStream.is_open()) {
+        return NULL;
+    }
+    char* input = new char[size + 1];
+    input[size] = 0;
+    inputStream.read(input, size);
+    if (inputStream.fail()) {
+        delete[] input;
+        return NULL;;
+    }
+    
+    return input;
+}
+
+void iterateFolder(const wchar_t * path, bool (*action)(const char* input, const char* expectedOutput)) {
+    wchar_t CURPATH[_MAX_PATH];
+    auto _ = _wgetcwd(CURPATH, _MAX_PATH);
+    wcscat_s(CURPATH, L"\\TestFiles\\");
+    wcscat_s(CURPATH, path);
+
+    if (!fs::is_directory(CURPATH)) {
+        FAIL() << CURPATH <<  L" is not a valid directory";
+        return;
+        }
+
+    bool filesProcessed = false;
+    for (const auto& entry : fs::directory_iterator(CURPATH)) {
+        std::string inpath = entry.path().string();
+        if (endsWith(inpath, ".in.xml")) {
+            fs::path outpath = replace(inpath, ".in.xml", ".out.xml");
+            auto outEntry = fs::directory_entry(outpath);
+
+            auto input = readFile(entry);
+            auto output = readFile(outEntry);
+
+            if (input != NULL && output != NULL) {
+                bool ok = action(input, output);
+                filesProcessed = true;
+                if (!ok){
+                    FAIL() << entry.path().filename().string() << " FAILED";
+                }
+            }
+
+            if (input) delete[] input;
+            if (output) delete[] output;
+        }
+    }
+    EXPECT_TRUE(filesProcessed) << "No files processed";
+}
+
+bool testPrettyPrint(const char* input, const char* expectedOutput) {
+
+    PrettyPrintParms parms;
+    parms.eol = "\r\n";
+    parms.tab = "\t";
+    parms.autocloseEmptyElements = true;
+    parms.insertIndents = true;
+    parms.insertNewLines = true;
+    parms.removeWhitespace = true;
+
+    auto prettyPrinter = XmlPrettyPrinter(input, strlen(input), parms);
+    prettyPrinter.Convert();
+    const std::string& output = prettyPrinter.Stream()->str();
+    return 0 == strcmp(expectedOutput, output.c_str());
+}
+
+TEST(PrettyPrint, XmlPretttyPrinterTests) {
+    iterateFolder(L"PrettyPrintFiles", testPrettyPrint);
+}

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.3" targetFramework="native" />
+</packages>

--- a/XMLTools.sln
+++ b/XMLTools.sln
@@ -1,8 +1,10 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XMLTools", "XMLTools.vcxproj", "{3CA1BA6F-6F79-2DC7-7E96-6B4E11A31EFC}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnitTests", "UnitTests\UnitTests.vcxproj", "{8B318363-5296-424F-956F-3DC409CF020E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,8 +22,19 @@ Global
 		{3CA1BA6F-6F79-2DC7-7E96-6B4E11A31EFC}.Debug|x64.Build.0 = Debug|x64
 		{3CA1BA6F-6F79-2DC7-7E96-6B4E11A31EFC}.Release|x64.ActiveCfg = Release|x64
 		{3CA1BA6F-6F79-2DC7-7E96-6B4E11A31EFC}.Release|x64.Build.0 = Release|x64
+		{8B318363-5296-424F-956F-3DC409CF020E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{8B318363-5296-424F-956F-3DC409CF020E}.Debug|Win32.Build.0 = Debug|Win32
+		{8B318363-5296-424F-956F-3DC409CF020E}.Debug|x64.ActiveCfg = Debug|x64
+		{8B318363-5296-424F-956F-3DC409CF020E}.Debug|x64.Build.0 = Debug|x64
+		{8B318363-5296-424F-956F-3DC409CF020E}.Release|Win32.ActiveCfg = Release|Win32
+		{8B318363-5296-424F-956F-3DC409CF020E}.Release|Win32.Build.0 = Release|Win32
+		{8B318363-5296-424F-956F-3DC409CF020E}.Release|x64.ActiveCfg = Release|x64
+		{8B318363-5296-424F-956F-3DC409CF020E}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0594A59B-6663-4C2E-8809-08DB62838BEC}
 	EndGlobalSection
 EndGlobal

--- a/XmlPrettyPrinter.cpp
+++ b/XmlPrettyPrinter.cpp
@@ -39,6 +39,9 @@ inline void XmlPrettyPrinter::StartNewElement() {
         TryCloseTag();
         AddNewline();
     }
+    else if (indented) {
+        AddNewline();
+    }
 }
 
 inline void XmlPrettyPrinter::WriteToken() {


### PR DESCRIPTION
Small fix in XmlPrettyPrinter (error detected by unit test :)

To test the pretty print including new lines and the lot: Add new xml files to TestFiles/PrettyPrintFiles
For other scenarios, such as 'fix indent only', we will need to create a new folder and a new unit test body.