### PR TITLE
Optional Numeric Predicate Support in XPath

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -61,6 +61,7 @@ void XmlToolsConfig::Read(std::wstring _configPath) {
 	ReadInt(L"maxIndentLevel", xmltoolsoptions.maxIndentLevel);
 	ReadBool(L"xpathOnStatusbar", xmltoolsoptions.xpathOnStatusbar);
 	ReadBool(L"dumpAttributeName", xmltoolsoptions.dumpAttributeName);
+	ReadBool(L"printXPathIndex", xmltoolsoptions.printXPathIndex);
 	ReadString(L"identityAttributes", xmltoolsoptions.identityAttributes);
 
 	ReadBool(L"convertAmp", xmltoolsoptions.convertAmp);
@@ -140,6 +141,7 @@ void XmlToolsConfig::Write() {
 	WriteInt(L"maxErrorsNum", xmltoolsoptions.maxErrorsNum);
 	WriteBool(L"xpathOnStatusbar", xmltoolsoptions.xpathOnStatusbar);
 	WriteBool(L"dumpAttributeName", xmltoolsoptions.dumpAttributeName);
+	WriteBool(L"printXPathIndex", xmltoolsoptions.printXPathIndex);
 	WriteString(L"identityAttributes", xmltoolsoptions.identityAttributes);
 
 	WriteBool(L"convertAmp", xmltoolsoptions.convertAmp);

--- a/Config.h
+++ b/Config.h
@@ -48,6 +48,7 @@ struct struct_xmltoolsoptions {
 
 	bool xpathOnStatusbar = true;
 	bool dumpAttributeName = false;
+	bool printXPathIndex = false;
 	std::wstring identityAttributes = L"id;name";
 
 	bool convertAmp = true;

--- a/OptionsDlg.cpp
+++ b/OptionsDlg.cpp
@@ -128,6 +128,8 @@ BOOL COptionsDlg::OnInitDialog() {
   pGrpStatusbar->AddSubItem(pTmpOption); vWStringProperties.push_back(pTmpOption);
   pTmpOption = new CMFCPropertyGridProperty(L"Dump attributes name", COleVariant((short)(xmltoolsoptions.dumpAttributeName ? VARIANT_TRUE : VARIANT_FALSE), VT_BOOL), L"Introduce the indentity attributes with their name. When enabled, elements are dumped like \".../sample[id='hello']/...\". When disabled, elements are dumped like \".../sample[hello]/...\".", (DWORD_PTR)&xmltoolsoptions.dumpAttributeName);
   pGrpStatusbar->AddSubItem(pTmpOption); vBoolProperties.push_back(pTmpOption);
+  pTmpOption = new CMFCPropertyGridProperty(L"Show XPath Element Index", COleVariant((short)(xmltoolsoptions.printXPathIndex ? VARIANT_TRUE : VARIANT_FALSE), VT_BOOL), L"Additionally shows the XPath Index of the current node. When enabled, the XPath of \"<a><b></b><b>Content</b></a>\" will resolve to \"/a/b[2]\" instead of \"/a/b\".", (DWORD_PTR)&xmltoolsoptions.printXPathIndex);
+  pGrpStatusbar->AddSubItem(pTmpOption); vBoolProperties.push_back(pTmpOption);
 
   CMFCPropertyGridProperty* pGrpXml2Txt = new CMFCPropertyGridProperty(L"XML to Text conversion");
   m_wndPropList.AddProperty(pGrpXml2Txt);

--- a/QuickXmlLib/QuickXml/src/XmlFormater.cpp
+++ b/QuickXmlLib/QuickXml/src/XmlFormater.cpp
@@ -474,12 +474,11 @@ namespace QuickXml {
 					std::string pathElement = std::string(token.chars + 1, token.size - 1);
 
 					if ((xpathMode & XPATH_MODE_WITHNODEINDEX) != 0) {
-						
+
 						std::map<std::string, size_t> depthMap;
 						// Push a new map for the new layer onto the depthElementMap
 						depthElementMap.push_back(depthMap);
-						
-						
+
 						if (depthElementMap.size() > 1) {
 							// increase amount of elements at current depth
 							depthElementMap.at(depthElementMap.size() - 2)[pathElement]++;
@@ -489,7 +488,6 @@ namespace QuickXml {
 								pathElement+= "[" + std::to_string(elementsInPosition) + "]";
 							}
 						}
-					
 					}
 
 					vPath.push_back(pathElement);
@@ -505,16 +503,11 @@ namespace QuickXml {
 					break;
 				}
 				case XmlTokenType::TagSelfClosingEnd: {
-					if (pushed_attr && !vPath.empty()) {
-						vPath.pop_back();
-					}
+					if (pushed_attr && !vPath.empty()) vPath.pop_back();
+					if ((xpathMode & XPATH_MODE_WITHNODEINDEX) != 0) depthElementMap.pop_back();
 					vPath.pop_back();
 					pushed_attr = false;
 					keep_attr_value = false;
-
-					if ((xpathMode & XPATH_MODE_WITHNODEINDEX) != 0) {
-						depthElementMap.pop_back();
-					}
 					break;
 				}
 				case XmlTokenType::AttrName: {

--- a/QuickXmlLib/QuickXml/src/XmlFormater.cpp
+++ b/QuickXmlLib/QuickXml/src/XmlFormater.cpp
@@ -459,6 +459,9 @@ namespace QuickXml {
 		std::vector<std::string> vPath;
 		bool pushed_attr = false;
 		bool keep_attr_value = false;
+		
+		// count elements of every depth layer in a map
+		std::vector<std::map<std::string, size_t>> depthElementMap;
 
 		while ((token = this->parser->parseNext()).type != XmlTokenType::EndOfFile) {
 			if (token.pos >= position) {
@@ -468,13 +471,35 @@ namespace QuickXml {
 
 			switch (token.type) {
 				case XmlTokenType::TagOpening: {
-					vPath.push_back(std::string(token.chars+1, token.size-1));
+					std::string pathElement = std::string(token.chars + 1, token.size - 1);
+
+					if ((xpathMode & XPATH_MODE_WITHNODEINDEX) != 0) {
+						
+						std::map<std::string, size_t> depthMap;
+						// Push a new map for the new layer onto the depthElementMap
+						depthElementMap.push_back(depthMap);
+						
+						
+						if (depthElementMap.size() > 1) {
+							// increase amount of elements at current depth
+							depthElementMap.at(depthElementMap.size() - 2)[pathElement]++;
+							int elementsInPosition = depthElementMap.at(depthElementMap.size() - 2)[pathElement];
+							// only show for index > 2, to minimize XPath
+							if (elementsInPosition > 1) {
+								pathElement+= "[" + std::to_string(elementsInPosition) + "]";
+							}
+						}
+					
+					}
+
+					vPath.push_back(pathElement);
 					pushed_attr = false;
 					keep_attr_value = false;
 					break;
 				}
 				case XmlTokenType::TagClosingEnd: {
 					if (!vPath.empty()) vPath.pop_back();
+					if ((xpathMode & XPATH_MODE_WITHNODEINDEX) != 0) depthElementMap.pop_back();
 					pushed_attr = false;
 					keep_attr_value = false;
 					break;
@@ -486,6 +511,10 @@ namespace QuickXml {
 					vPath.pop_back();
 					pushed_attr = false;
 					keep_attr_value = false;
+
+					if ((xpathMode & XPATH_MODE_WITHNODEINDEX) != 0) {
+						depthElementMap.pop_back();
+					}
 					break;
 				}
 				case XmlTokenType::AttrName: {

--- a/QuickXmlLib/QuickXml/src/XmlFormater.h
+++ b/QuickXmlLib/QuickXml/src/XmlFormater.h
@@ -2,11 +2,13 @@
 
 #include <sstream>
 #include <vector>
+#include <map>
 #include "XmlParser.h"
 
 #define XPATH_MODE_BASIC				(1 << 0)
 #define XPATH_MODE_WITHNAMESPACE		(1 << 1)
 #define XPATH_MODE_KEEPIDATTRIBUTE		(1 << 2)
+#define XPATH_MODE_WITHNODEINDEX		(1 << 3)
 
 namespace QuickXml {
 	struct XmlFormaterParamsType {

--- a/QuickXmlLib/QuickXmlTests/src/QuickXmlTests.cpp
+++ b/QuickXmlLib/QuickXmlTests/src/QuickXmlTests.cpp
@@ -334,13 +334,13 @@ namespace QuickXmlTests {
 			std::string ref("/x:a/x:b/d");
 
 			XmlFormater formater(xml.c_str(), xml.length());
-			std::stringstream* out = formater.currentPath(34, true);
+			std::stringstream* out = formater.currentPath(34, XPATH_MODE_WITHNAMESPACE);
 			std::string tmp(out->str());
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
 
 			ref = "/a/b/d";
-			out = formater.currentPath(34, false);
+			out = formater.currentPath(34, XPATH_MODE_BASIC);
 			tmp = out->str();
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
@@ -351,7 +351,7 @@ namespace QuickXmlTests {
 			std::string ref("/x:a/x:b/d");
 
 			XmlFormater formater(xml.c_str(), xml.length());
-			std::stringstream* out = formater.currentPath(33, true);
+			std::stringstream* out = formater.currentPath(33, XPATH_MODE_WITHNAMESPACE);
 			std::string tmp(out->str());
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
@@ -368,13 +368,13 @@ namespace QuickXmlTests {
 			std::string ref("/x:a/x:b");
 
 			XmlFormater formater(xml.c_str(), xml.length());
-			std::stringstream* out = formater.currentPath(31, true);
+			std::stringstream* out = formater.currentPath(31, XPATH_MODE_WITHNAMESPACE);
 			std::string tmp(out->str());
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
 
 			ref = "/a/b";
-			out = formater.currentPath(31, false);
+			out = formater.currentPath(31, XPATH_MODE_BASIC);
 			tmp = out->str();
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
@@ -385,13 +385,30 @@ namespace QuickXmlTests {
 			std::string ref("/x:a/x:b/d/@x:x");
 
 			XmlFormater formater(xml.c_str(), xml.length());
-			std::stringstream* out = formater.currentPath(58, true);
+			std::stringstream* out = formater.currentPath(58, XPATH_MODE_WITHNAMESPACE);
 			std::string tmp(out->str());
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
 
 			ref = "/a/b/d/@x";
 			out = formater.currentPath(58, false);
+			tmp = out->str();
+
+			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
+		}
+
+		TEST_METHOD(CurrentPathTest05) {
+			std::string xml("<root><div></div><div>test123</div></root>");
+			std::string ref("/root/div[2]");
+
+			XmlFormater formater(xml.c_str(), xml.length());
+			std::stringstream* out = formater.currentPath(24, XPATH_MODE_WITHNODEINDEX);
+			std::string tmp(out->str());
+
+			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
+
+			ref = "/root/div";
+			out = formater.currentPath(24, XPATH_MODE_BASIC);
 			tmp = out->str();
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));

--- a/ToolsXPath.cpp
+++ b/ToolsXPath.cpp
@@ -54,9 +54,7 @@ void printCurrentXPathInStatusbar() {
     HWND hCurrentEditView = getCurrentHScintilla(currentEdit);
     
     int xpathmode = XPATH_MODE_WITHNAMESPACE | XPATH_MODE_KEEPIDATTRIBUTE;
-    if (xmltoolsoptions.printXPathIndex) {
-        xpathmode |= XPATH_MODE_WITHNODEINDEX;
-    }
+    if (xmltoolsoptions.printXPathIndex) xpathmode |= XPATH_MODE_WITHNODEINDEX;
    
     std::wstring tmp = currentXPath(xpathmode);
     if (tmp.length() == 0) tmp = L" ";  // empty value has no effect on NPPM_SETSTATUSBAR
@@ -66,7 +64,7 @@ void printCurrentXPathInStatusbar() {
 void getCurrentXPath(bool precise) {
     dbgln("getCurrentXPath()");
 
-    std::wstring nodepath(currentXPath(precise ? XPATH_MODE_WITHNAMESPACE : XPATH_MODE_BASIC));
+    std::wstring nodepath(currentXPath(precise ? XPATH_MODE_WITHNAMESPACE | XPATH_MODE_WITHNODEINDEX : XPATH_MODE_BASIC));
     std::wstring tmpmsg(L"Current node cannot be resolved.");
 
     if (nodepath.length() > 0) {

--- a/ToolsXPath.cpp
+++ b/ToolsXPath.cpp
@@ -52,8 +52,13 @@ void printCurrentXPathInStatusbar() {
     int currentEdit;
     ::SendMessage(nppData._nppHandle, NPPM_GETCURRENTSCINTILLA, 0, (LPARAM)&currentEdit);
     HWND hCurrentEditView = getCurrentHScintilla(currentEdit);
-
-    std::wstring tmp = currentXPath(XPATH_MODE_WITHNAMESPACE | XPATH_MODE_KEEPIDATTRIBUTE);
+    
+    int xpathmode = XPATH_MODE_WITHNAMESPACE | XPATH_MODE_KEEPIDATTRIBUTE;
+    if (xmltoolsoptions.printXPathIndex) {
+        xpathmode |= XPATH_MODE_WITHNODEINDEX;
+    }
+   
+    std::wstring tmp = currentXPath(xpathmode);
     if (tmp.length() == 0) tmp = L" ";  // empty value has no effect on NPPM_SETSTATUSBAR
     ::SendMessage(nppData._nppHandle, NPPM_SETSTATUSBAR, STATUSBAR_DOC_TYPE, (LPARAM) tmp.c_str());
 }


### PR DESCRIPTION
I recently worked alot with large XML's and made heavily use of xmltools.
The only thing i was missing, were numeric predicates in the XPath, when there are multiple elements of the same type.

So given the following XML:
`<a><b></b><b>Cursor_is_here</b></a>`
Currently both `b` Elements have the same XPath: `/a/b`.

With my changes, you can enable numeric predicates, so that the same Example would resolve to: `/a/b[2]`
This will resolve [Issue 139](https://github.com/morbac/xmltools/issues/139)


