### PR TITLE
Always show XPath Index when enabled, disable attributes

### DIFF
--- a/OptionsDlg.cpp
+++ b/OptionsDlg.cpp
@@ -128,7 +128,7 @@ BOOL COptionsDlg::OnInitDialog() {
   pGrpStatusbar->AddSubItem(pTmpOption); vWStringProperties.push_back(pTmpOption);
   pTmpOption = new CMFCPropertyGridProperty(L"Dump attributes name", COleVariant((short)(xmltoolsoptions.dumpAttributeName ? VARIANT_TRUE : VARIANT_FALSE), VT_BOOL), L"Introduce the indentity attributes with their name. When enabled, elements are dumped like \".../sample[id='hello']/...\". When disabled, elements are dumped like \".../sample[hello]/...\".", (DWORD_PTR)&xmltoolsoptions.dumpAttributeName);
   pGrpStatusbar->AddSubItem(pTmpOption); vBoolProperties.push_back(pTmpOption);
-  pTmpOption = new CMFCPropertyGridProperty(L"Show XPath Element Index", COleVariant((short)(xmltoolsoptions.printXPathIndex ? VARIANT_TRUE : VARIANT_FALSE), VT_BOOL), L"Additionally shows the XPath Index of the current node. When enabled, the XPath of \"<a><b></b><b>Content</b></a>\" will resolve to \"/a/b[2]\" instead of \"/a/b\".", (DWORD_PTR)&xmltoolsoptions.printXPathIndex);
+  pTmpOption = new CMFCPropertyGridProperty(L"Show XPath Element Index", COleVariant((short)(xmltoolsoptions.printXPathIndex ? VARIANT_TRUE : VARIANT_FALSE), VT_BOOL), L"Additionally shows the XPath Index of the current node. When enabled, the XPath of \"<a><b></b><b>Content</b></a>\" will resolve to \"/a/b[2]\" instead of \"/a/b\". This will disable other attributes.", (DWORD_PTR)&xmltoolsoptions.printXPathIndex);
   pGrpStatusbar->AddSubItem(pTmpOption); vBoolProperties.push_back(pTmpOption);
 
   CMFCPropertyGridProperty* pGrpXml2Txt = new CMFCPropertyGridProperty(L"XML to Text conversion");

--- a/QuickXmlLib/QuickXml/src/XmlFormater.cpp
+++ b/QuickXmlLib/QuickXml/src/XmlFormater.cpp
@@ -483,10 +483,7 @@ namespace QuickXml {
 							// increase amount of elements at current depth
 							depthElementMap.at(depthElementMap.size() - 2)[pathElement]++;
 							int elementsInPosition = depthElementMap.at(depthElementMap.size() - 2)[pathElement];
-							// only show for index > 2, to minimize XPath
-							if (elementsInPosition > 1) {
-								pathElement+= "[" + std::to_string(elementsInPosition) + "]";
-							}
+							pathElement+= "[" + std::to_string(elementsInPosition) + "]";
 						}
 					}
 
@@ -511,6 +508,9 @@ namespace QuickXml {
 					break;
 				}
 				case XmlTokenType::AttrName: {
+					// We dont need Attributes, when we have an exact Path with Indices to the Node.
+					if (xpathMode & XPATH_MODE_WITHNODEINDEX) break;
+
 					if (pushed_attr && !vPath.empty()) {
 						vPath.pop_back();
 					}

--- a/QuickXmlLib/QuickXmlTests/src/QuickXmlTests.cpp
+++ b/QuickXmlLib/QuickXmlTests/src/QuickXmlTests.cpp
@@ -412,6 +412,12 @@ namespace QuickXmlTests {
 			tmp = out->str();
 
 			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
+
+			ref = "/root/div[1]";
+			out = formater.currentPath(11, XPATH_MODE_WITHNODEINDEX);
+			tmp = out->str();
+
+			Assert::IsTrue(0 == tmp.compare(ref.c_str()));
 		}
 	};
 }


### PR DESCRIPTION
Fix, discussed in https://github.com/morbac/xmltools/pull/149
I also disabled attributes when numeric predicates are enabled, as its not possible to display the attribute and index in one selector.