### PR TITLE
Restore process working directory at end of performXMLCheck() to fix issue #179

### DIFF
--- a/ToolsXmlValidate.cpp
+++ b/ToolsXmlValidate.cpp
@@ -13,10 +13,16 @@
 
 #include <string>
 
+#include <direct.h>
+
 using namespace QuickXml;
 
 int performXMLCheck(int informIfNoError) {
     dbgln("performXMLCheck()");
+
+    // Save process preexisting current working directory and drive.
+    int prevDrive = _getdrive();
+    wchar_t* prevPath = _wgetdcwd(prevDrive, NULL, MAX_PATH);
 
     // 0. change current folder
     TCHAR currenPath[MAX_PATH] = { '\0' };
@@ -57,6 +63,13 @@ int performXMLCheck(int informIfNoError) {
     }
     else {
         displayXMLErrors(wrapper->getLastErrors(), hCurrentEditView, L"XML Parsing error");
+    }
+
+    // Restore process preexisting current working directory (drive restored implicitly).
+    if (prevPath)
+    {
+        _wchdir(prevPath);
+        free(prevPath);
     }
 
     delete wrapper;


### PR DESCRIPTION
Attempt to fix issue #179, where a directory containing an xml file cannot be renamed or deleted after editing a contained XML file.  Fix by restoring the working directory to its previous state.

Known limitations:
- Written by a non-C/C++ developer, so string handling or something else may be wrong.
- Does not address any other locations where the process working directory is changed with _wchdir(), such as in XmlValidation().
